### PR TITLE
Removes order when over 3,000 records

### DIFF
--- a/app/assets/stylesheets/active_scaffold_export.css.erb
+++ b/app/assets/stylesheets/active_scaffold_export.css.erb
@@ -22,6 +22,13 @@
   margin-bottom: .25em;
   float: left;
 }
+span.hint {
+  font-size: 12px;
+  padding: 10px 0;
+  margin-bottom: 10px;
+  display: inline;
+  color: #aaa;
+}
 .active-scaffold div.show_export-view label #delimiter {
   font-family: monospace;
 }

--- a/app/views/active_scaffold_overrides/_export_form_body.html.erb
+++ b/app/views/active_scaffold_overrides/_export_form_body.html.erb
@@ -29,6 +29,8 @@
   <div class="option checkbox-wrapper">
     <%= content_tag(:label, radio_button_tag('full_download', true, export_config.default_full_download) + " #{as_(:all_pages)}".html_safe) if export_config.allow_full_download %>
   </div>
+  <span class="hint">If more than 3,000 records are selected for export, the order may be lost.</span>
+
   <div class="separator"></div>
   <% if active_scaffold_config.export_xlsx_avaliable %>
     <div class="option checkbox-wrapper">

--- a/app/views/active_scaffold_overrides/_export_form_body.html.erb
+++ b/app/views/active_scaffold_overrides/_export_form_body.html.erb
@@ -29,7 +29,7 @@
   <div class="option checkbox-wrapper">
     <%= content_tag(:label, radio_button_tag('full_download', true, export_config.default_full_download) + " #{as_(:all_pages)}".html_safe) if export_config.allow_full_download %>
   </div>
-  <span class="hint">If more than 3,000 records are selected for export, the order may be lost.</span>
+  <span class="hint">If more than <%= number_with_delimiter(ActiveScaffold::Actions::Export::PAGE_SIZE) %> records are selected for export, the order may be lost.</span>
 
   <div class="separator"></div>
   <% if active_scaffold_config.export_xlsx_avaliable %>

--- a/lib/active_scaffold/actions/export.rb
+++ b/lib/active_scaffold/actions/export.rb
@@ -113,6 +113,11 @@ module ActiveScaffold::Actions
           :per_page => 3000,
           :page => 1
         })
+        query = beginning_of_chain.where(nil) # where(nil) is needed because we need a relation
+        # NOTE: we must use :include in the count query, because some conditions may reference other tables
+        count = count_items(query, finder_options(find_options), finder_options[:count_includes])
+        find_options[:sorting] = nil if count > 3000
+
         find_page(find_options).pager.each do |page|
           yield page.items
         end

--- a/lib/active_scaffold/actions/export.rb
+++ b/lib/active_scaffold/actions/export.rb
@@ -1,5 +1,7 @@
 module ActiveScaffold::Actions
   module Export
+    PAGE_SIZE = 3000
+
     def self.included(base)
       base.before_action :export_authorized?, :only => [:export]
       base.before_action :show_export_authorized?, :only => [:show_export]
@@ -110,13 +112,13 @@ module ActiveScaffold::Actions
 
       if params[:full_download] == 'true'
         find_options.merge!({
-          :per_page => 3000,
+          :per_page => PAGE_SIZE,
           :page => 1
         })
         query = beginning_of_chain.where(nil) # where(nil) is needed because we need a relation
         # NOTE: we must use :include in the count query, because some conditions may reference other tables
         count = count_items(query, finder_options(find_options), finder_options[:count_includes])
-        find_options[:sorting] = nil if count > 3000
+        find_options[:sorting] = nil if count > PAGE_SIZE
 
         find_page(find_options).pager.each do |page|
           yield page.items


### PR DESCRIPTION
When exporting by a field that is changing fairly constantly, the order at which the user choose might result in the export creating duplicate/skipped records due to batching.

The design approach choose was to drop the user's desired order when over 3,000 records are exported.

https://github.com/cetani/Activate/issues/2365